### PR TITLE
Update Boundary Condition in domains.cc

### DIFF
--- a/Examples/Tasks/domains/domains.cc
+++ b/Examples/Tasks/domains/domains.cc
@@ -12,7 +12,7 @@ enum TaskID {
 
 void print_point(DomainPoint d) {
   printf("The point is <");
-  for(int i = 0; i <= d.dim - 1; i++) 
+  for(int i = 0; i < d.dim - 1; i++) 
     printf("%lld,",d[i]);
   if (d.dim > 0) 
     printf("%lld>\n",d[d.dim-1]);


### PR DESCRIPTION
The original code is the following:
```
void print_point(DomainPoint d) {
  printf("The point is <");
  for(int i = 0; i <= d.dim - 1; i++) 
    printf("%lld,",d[i]);
  if (d.dim > 0) 
    printf("%lld>\n",d[d.dim-1]);
}
```
Suppose `d.dim=1`, I assume it would print `d[0]` twice.
In general, for an n-dim DomainPoint (i.e., `d.dim=n`), I presume the above code will print (n+1) numbers.
The fix is to change the boundary condition of `<=` to `<` in the `for` loop.